### PR TITLE
Fixing permissions in dependencies

### DIFF
--- a/python/flask/Dockerfile
+++ b/python/flask/Dockerfile
@@ -21,7 +21,7 @@ RUN useradd -ms /bin/bash apiuser
 USER apiuser
 
 # Copy the Python dependencies from the builder image and set the PATH
-COPY --from=builder /root/.local /home/apiuser/.local
+COPY --chown=apiuser --from=builder /root/.local /home/apiuser/.local
 ENV PATH=/home/apiuser/.local/bin:$PATH
 
 # Run the flask application


### PR DESCRIPTION
The `COPY` command is done as root, so, the directory `/home/apiuser/.local` and its content is owned by root. This change fixes the ownership problem.

Permissions before the change:

```
docker ❯ ls -latrh /home/apiuser
total 24K
-rw-r--r-- 1 apiuser apiuser  807 Mar 27  2022 .profile
-rw-r--r-- 1 apiuser apiuser 3.5K Mar 27  2022 .bashrc
-rw-r--r-- 1 apiuser apiuser  220 Mar 27  2022 .bash_logout
drwxr-xr-x 1 root    root    4.0K Apr  6 13:09 ..
drwxr-xr-x 4 root    root    4.0K Apr  6 13:27 .local
drwxr-xr-x 1 apiuser apiuser 4.0K Apr  6 13:27 .
apiuser@037d396d34ea / [competent_leakey]
```

Permissions after the change:

```
docker ❯ ls -larth /home/apiuser/
total 24K
-rw-r--r-- 1 apiuser apiuser  807 Mar 27  2022 .profile
-rw-r--r-- 1 apiuser apiuser 3.5K Mar 27  2022 .bashrc
-rw-r--r-- 1 apiuser apiuser  220 Mar 27  2022 .bash_logout
drwxr-xr-x 1 root    root    4.0K Apr  6 13:29 ..
drwxr-xr-x 4 apiuser apiuser 4.0K Apr  6 13:30 .local
drwxr-xr-x 1 apiuser apiuser 4.0K Apr  6 13:30 .
apiuser@a9af48264a69 / [great_shirley]
```